### PR TITLE
Change input param to market

### DIFF
--- a/contracts/OverlayV1State.sol
+++ b/contracts/OverlayV1State.sol
@@ -21,10 +21,10 @@ contract OverlayV1State is
 
     /// @notice Gets relevant market info to aggregate calls into a
     /// @notice single function
-    /// @dev WARNING: makes many calls to market associated with feed
+    /// @dev WARNING: makes many calls to market
     /// @return state_ as the current aggregate market state
-    function marketState(address feed) external view returns (MarketState memory state_) {
-        IOverlayV1Market market = _getMarket(feed);
+    function marketState(IOverlayV1Market market) external view returns (MarketState memory state_) {
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
 
         (uint256 oiLong, uint256 oiShort) = _ois(market);

--- a/contracts/OverlayV1State.sol
+++ b/contracts/OverlayV1State.sol
@@ -23,7 +23,7 @@ contract OverlayV1State is
     /// @notice single function
     /// @dev WARNING: makes many calls to market associated with feed
     /// @return state_ as the current aggregate market state
-    function state(address feed) external view returns (MarketState memory state_) {
+    function marketState(address feed) external view returns (MarketState memory state_) {
         IOverlayV1Market market = _getMarket(feed);
         Oracle.Data memory data = _getOracleData(feed);
 

--- a/contracts/OverlayV1State.sol
+++ b/contracts/OverlayV1State.sol
@@ -19,11 +19,10 @@ contract OverlayV1State is
 {
     constructor(IOverlayV1Factory _factory) OverlayV1BaseState(_factory) {}
 
-    /// @notice Gets relevant market info into a single function
-    /// @notice to aggregate calls into one function
+    /// @notice Gets relevant market info to aggregate calls into a
+    /// @notice single function
     /// @dev WARNING: makes many calls to market associated with feed
     /// @return state_ as the current aggregate market state
-    // TODO: test
     function state(address feed) external view returns (MarketState memory state_) {
         IOverlayV1Market market = _getMarket(feed);
         Oracle.Data memory data = _getOracleData(feed);

--- a/contracts/OverlayV1State.sol
+++ b/contracts/OverlayV1State.sol
@@ -18,4 +18,28 @@ contract OverlayV1State is
     OverlayV1PositionState
 {
     constructor(IOverlayV1Factory _factory) OverlayV1BaseState(_factory) {}
+
+    /// @notice Gets relevant market info into a single function
+    /// @notice to aggregate calls into one function
+    /// @dev WARNING: makes many calls to market associated with feed
+    /// @return state_ as the current aggregate market state
+    // TODO: test
+    function state(address feed) external view returns (MarketState memory state_) {
+        IOverlayV1Market market = _getMarket(feed);
+        Oracle.Data memory data = _getOracleData(feed);
+
+        (uint256 oiLong, uint256 oiShort) = _ois(market);
+        state_ = MarketState({
+            bid: _bid(market, data, 0),
+            ask: _ask(market, data, 0),
+            mid: _mid(data),
+            volumeBid: _volumeBid(market, data, 0),
+            volumeAsk: _volumeAsk(market, data, 0),
+            oiLong: oiLong,
+            oiShort: oiShort,
+            capOi: _capOi(market, data),
+            circuitBreakerLevel: _circuitBreakerLevel(market),
+            fundingRate: _fundingRate(market)
+        });
+    }
 }

--- a/contracts/OverlayV1State.sol
+++ b/contracts/OverlayV1State.sol
@@ -23,7 +23,11 @@ contract OverlayV1State is
     /// @notice single function
     /// @dev WARNING: makes many calls to market
     /// @return state_ as the current aggregate market state
-    function marketState(IOverlayV1Market market) external view returns (MarketState memory state_) {
+    function marketState(IOverlayV1Market market)
+        external
+        view
+        returns (MarketState memory state_)
+    {
         address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
 

--- a/contracts/interfaces/IOverlayV1State.sol
+++ b/contracts/interfaces/IOverlayV1State.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.10;
 
+import "@overlay/v1-core/contracts/interfaces/IOverlayV1Market.sol";
+
 import "./state/IOverlayV1BaseState.sol";
 import "./state/IOverlayV1PriceState.sol";
 import "./state/IOverlayV1OIState.sol";
@@ -25,5 +27,5 @@ interface IOverlayV1State is
         int256 fundingRate;
     }
 
-    function marketState(address feed) external view returns (MarketState memory state_);
+    function marketState(IOverlayV1Market market) external view returns (MarketState memory state_);
 }

--- a/contracts/interfaces/IOverlayV1State.sol
+++ b/contracts/interfaces/IOverlayV1State.sol
@@ -11,4 +11,19 @@ interface IOverlayV1State is
     IOverlayV1PriceState,
     IOverlayV1OIState,
     IOverlayV1PositionState
-{}
+{
+    struct MarketState {
+        uint256 bid;
+        uint256 ask;
+        uint256 mid;
+        uint256 volumeBid;
+        uint256 volumeAsk;
+        uint256 oiLong;
+        uint256 oiShort;
+        uint256 capOi;
+        uint256 circuitBreakerLevel;
+        int256 fundingRate;
+    }
+
+    function state(address feed) external view returns (MarketState memory state_);
+}

--- a/contracts/interfaces/IOverlayV1State.sol
+++ b/contracts/interfaces/IOverlayV1State.sol
@@ -25,5 +25,5 @@ interface IOverlayV1State is
         int256 fundingRate;
     }
 
-    function state(address feed) external view returns (MarketState memory state_);
+    function marketState(address feed) external view returns (MarketState memory state_);
 }

--- a/contracts/interfaces/IOverlayV1State.sol
+++ b/contracts/interfaces/IOverlayV1State.sol
@@ -27,5 +27,8 @@ interface IOverlayV1State is
         int256 fundingRate;
     }
 
-    function marketState(IOverlayV1Market market) external view returns (MarketState memory state_);
+    function marketState(IOverlayV1Market market)
+        external
+        view
+        returns (MarketState memory state_);
 }

--- a/contracts/interfaces/state/IOverlayV1OIState.sol
+++ b/contracts/interfaces/state/IOverlayV1OIState.sol
@@ -8,7 +8,10 @@ import "./IOverlayV1PriceState.sol";
 
 interface IOverlayV1OIState is IOverlayV1BaseState, IOverlayV1PriceState {
     // aggregate open interest values on market
-    function ois(IOverlayV1Market market) external view returns (uint256 oiLong_, uint256 oiShort_);
+    function ois(IOverlayV1Market market)
+        external
+        view
+        returns (uint256 oiLong_, uint256 oiShort_);
 
     // cap on aggregate open interest on market
     function capOi(IOverlayV1Market market) external view returns (uint256 capOi_);

--- a/contracts/interfaces/state/IOverlayV1OIState.sol
+++ b/contracts/interfaces/state/IOverlayV1OIState.sol
@@ -1,31 +1,33 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.10;
 
+import "@overlay/v1-core/contracts/interfaces/IOverlayV1Market.sol";
+
 import "./IOverlayV1BaseState.sol";
 import "./IOverlayV1PriceState.sol";
 
 interface IOverlayV1OIState is IOverlayV1BaseState, IOverlayV1PriceState {
-    // aggregate open interest values on market associated with feed
-    function ois(address feed) external view returns (uint256 oiLong_, uint256 oiShort_);
+    // aggregate open interest values on market
+    function ois(IOverlayV1Market market) external view returns (uint256 oiLong_, uint256 oiShort_);
 
-    // cap on aggregate open interest on market associated with feed
-    function capOi(address feed) external view returns (uint256 capOi_);
+    // cap on aggregate open interest on market
+    function capOi(IOverlayV1Market market) external view returns (uint256 capOi_);
 
     // fraction of cap on aggregate open interest given oi amount
-    function fractionOfCapOi(address feed, uint256 oi)
+    function fractionOfCapOi(IOverlayV1Market market, uint256 oi)
         external
         view
         returns (uint256 fractionOfCapOi_);
 
-    // funding rate on market associated with feed
-    function fundingRate(address feed) external view returns (int256 fundingRate_);
+    // funding rate on market
+    function fundingRate(IOverlayV1Market market) external view returns (int256 fundingRate_);
 
-    // circuit breaker level on market associated with feed
-    function circuitBreakerLevel(address feed)
+    // circuit breaker level on market
+    function circuitBreakerLevel(IOverlayV1Market market)
         external
         view
         returns (uint256 circuitBreakerLevel_);
 
-    // rolling minted amount on market associated with feed
-    function minted(address feed) external view returns (int256 minted_);
+    // rolling minted amount on market
+    function minted(IOverlayV1Market market) external view returns (int256 minted_);
 }

--- a/contracts/interfaces/state/IOverlayV1PositionState.sol
+++ b/contracts/interfaces/state/IOverlayV1PositionState.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.10;
 
+import "@overlay/v1-core/contracts/interfaces/IOverlayV1Market.sol";
 import "@overlay/v1-core/contracts/libraries/Position.sol";
 
 import "./IOverlayV1BaseState.sol";
@@ -8,95 +9,93 @@ import "./IOverlayV1OIState.sol";
 import "./IOverlayV1PriceState.sol";
 
 interface IOverlayV1PositionState is IOverlayV1BaseState, IOverlayV1PriceState, IOverlayV1OIState {
-    // position on the market associated with feed
+    // position on the market
     function position(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (Position.Info memory position_);
 
-    // debt of position on the market associated with feed
+    // debt of position on the market
     function debt(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 debt_);
 
-    // cost basis of position on the market associated with feed
+    // cost basis of position on the market
     function cost(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 cost_);
 
-    // open interest of position on the market associated with feed
+    // open interest of position on the market
     function oi(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 oi_);
 
-    // collateral backing position on the market associated with feed
+    // collateral backing position on the market
     function collateral(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 collateral_);
 
-    // value of position on the market associated with feed
+    // value of position on the market
     function value(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 value_);
 
-    // notional of position on the market associated with feed
+    // notional of position on the market
     function notional(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 notional_);
 
-    // trading fee charged to unwind position on the market associated with feed
+    // trading fee charged to unwind position on the market
     function tradingFee(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 tradingFee_);
 
-    // whether position is liquidatable on the market associated with feed
+    // whether position is liquidatable on the market
     function liquidatable(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (bool liquidatable_);
 
-    // liquidation fee rewarded to liquidator for position on market associated
-    // with feed
+    // liquidation fee rewarded to liquidator for position on market
     function liquidationFee(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 liquidationFee_);
 
-    // maintenance margin requirement for position on market associated with feed
+    // maintenance margin requirement for position on market
     function maintenanceMargin(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 maintenanceMargin_);
 
-    // remaining margin before liquidation for position on market associated
-    // with feed
+    // remaining margin before liquidation for position on market
     function marginExcessBeforeLiquidation(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (int256 excess_);
 
-    // liquidation price for position on market associated with feed
+    // liquidation price for position on market
     function liquidationPrice(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 liquidationPrice_);

--- a/contracts/interfaces/state/IOverlayV1PriceState.sol
+++ b/contracts/interfaces/state/IOverlayV1PriceState.sol
@@ -1,34 +1,34 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.10;
 
+import "@overlay/v1-core/contracts/interfaces/IOverlayV1Market.sol";
+
 import "./IOverlayV1BaseState.sol";
 
 interface IOverlayV1PriceState is IOverlayV1BaseState {
-    // bid on the market associated with the feed given new volume from fractionOfCapOi
-    function bid(address feed, uint256 fractionOfCapOi) external view returns (uint256 bid_);
+    // bid on the market given new volume from fractionOfCapOi
+    function bid(IOverlayV1Market market, uint256 fractionOfCapOi) external view returns (uint256 bid_);
 
-    // ask on the market associated with the feed given new volume from fractionOfCapOi
-    function ask(address feed, uint256 fractionOfCapOi) external view returns (uint256 ask_);
+    // ask on the market given new volume from fractionOfCapOi
+    function ask(IOverlayV1Market market, uint256 fractionOfCapOi) external view returns (uint256 ask_);
 
-    // mid on the market associated with the feed
-    function mid(address feed) external view returns (uint256 mid_);
+    // mid on the market
+    function mid(IOverlayV1Market market) external view returns (uint256 mid_);
 
-    // volume on the bid of the market associated with the feed given
-    // new volume from fractionOfCapOi
-    function volumeBid(address feed, uint256 fractionOfCapOi)
+    // volume on the bid of the market given new volume from fractionOfCapOi
+    function volumeBid(IOverlayV1Market market, uint256 fractionOfCapOi)
         external
         view
         returns (uint256 volumeBid_);
 
-    // volume on the ask of the market associated with the feed given
-    // new volume from fractionOfCapOi
-    function volumeAsk(address feed, uint256 fractionOfCapOi)
+    // volume on the ask of the market given new volume from fractionOfCapOi
+    function volumeAsk(IOverlayV1Market market, uint256 fractionOfCapOi)
         external
         view
         returns (uint256 volumeAsk_);
 
-    // bid, ask, mid prices of the market associated with the feed
-    function prices(address feed)
+    // bid, ask, mid prices of the market
+    function prices(IOverlayV1Market market)
         external
         view
         returns (
@@ -37,6 +37,6 @@ interface IOverlayV1PriceState is IOverlayV1BaseState {
             uint256 mid_
         );
 
-    // bid, ask volumes of the market associated with the feed
-    function volumes(address feed) external view returns (uint256 volumeBid_, uint256 volumeAsk_);
+    // bid, ask volumes of the market
+    function volumes(IOverlayV1Market market) external view returns (uint256 volumeBid_, uint256 volumeAsk_);
 }

--- a/contracts/interfaces/state/IOverlayV1PriceState.sol
+++ b/contracts/interfaces/state/IOverlayV1PriceState.sol
@@ -7,10 +7,16 @@ import "./IOverlayV1BaseState.sol";
 
 interface IOverlayV1PriceState is IOverlayV1BaseState {
     // bid on the market given new volume from fractionOfCapOi
-    function bid(IOverlayV1Market market, uint256 fractionOfCapOi) external view returns (uint256 bid_);
+    function bid(IOverlayV1Market market, uint256 fractionOfCapOi)
+        external
+        view
+        returns (uint256 bid_);
 
     // ask on the market given new volume from fractionOfCapOi
-    function ask(IOverlayV1Market market, uint256 fractionOfCapOi) external view returns (uint256 ask_);
+    function ask(IOverlayV1Market market, uint256 fractionOfCapOi)
+        external
+        view
+        returns (uint256 ask_);
 
     // mid on the market
     function mid(IOverlayV1Market market) external view returns (uint256 mid_);
@@ -38,5 +44,8 @@ interface IOverlayV1PriceState is IOverlayV1BaseState {
         );
 
     // bid, ask volumes of the market
-    function volumes(IOverlayV1Market market) external view returns (uint256 volumeBid_, uint256 volumeAsk_);
+    function volumes(IOverlayV1Market market)
+        external
+        view
+        returns (uint256 volumeBid_, uint256 volumeAsk_);
 }

--- a/contracts/state/OverlayV1OIState.sol
+++ b/contracts/state/OverlayV1OIState.sol
@@ -131,7 +131,11 @@ abstract contract OverlayV1OIState is IOverlayV1OIState, OverlayV1BaseState, Ove
     /// @notice accounting for funding
     /// @return oiLong_ as the current open interest long
     /// @return oiShort_ as the current open interest short
-    function ois(IOverlayV1Market market) external view returns (uint256 oiLong_, uint256 oiShort_) {
+    function ois(IOverlayV1Market market)
+        external
+        view
+        returns (uint256 oiLong_, uint256 oiShort_)
+    {
         (oiLong_, oiShort_) = _ois(market);
     }
 
@@ -175,7 +179,6 @@ abstract contract OverlayV1OIState is IOverlayV1OIState, OverlayV1BaseState, Ove
         view
         returns (uint256 circuitBreakerLevel_)
     {
-        IOverlayV1Market market = _getMarket(feed);
         circuitBreakerLevel_ = _circuitBreakerLevel(market);
     }
 

--- a/contracts/state/OverlayV1OIState.sol
+++ b/contracts/state/OverlayV1OIState.sol
@@ -128,71 +128,61 @@ abstract contract OverlayV1OIState is IOverlayV1OIState, OverlayV1BaseState, Ove
     }
 
     /// @notice Gets the current open interest values on the Overlay market
-    /// @notice associated with the given feed address accounting for funding
+    /// @notice accounting for funding
     /// @return oiLong_ as the current open interest long
     /// @return oiShort_ as the current open interest short
-    function ois(address feed) external view returns (uint256 oiLong_, uint256 oiShort_) {
-        IOverlayV1Market market = _getMarket(feed);
+    function ois(IOverlayV1Market market) external view returns (uint256 oiLong_, uint256 oiShort_) {
         (oiLong_, oiShort_) = _ois(market);
     }
 
     /// @notice Gets the current cap on open interest on the Overlay market
-    /// @notice associated with the given feed address accounting for
-    /// @notice front and back-running bounds
+    /// @notice accounting for front and back-running bounds
     /// @return capOi_ as the current open interest cap
-    function capOi(address feed) external view returns (uint256 capOi_) {
-        IOverlayV1Market market = _getMarket(feed);
+    function capOi(IOverlayV1Market market) external view returns (uint256 capOi_) {
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         capOi_ = _capOi(market, data);
     }
 
     /// @notice Gets the fraction of the current open interest cap the
     /// @notice given oi contracts represents on the Overlay market
-    /// @notice associated with the given feed address
     /// @dev fractionOfCapOi = oi / capOi is FixedPoint
     /// @return fractionOfCapOi_ as fraction of open interest cap given oi is
-    function fractionOfCapOi(address feed, uint256 oi)
+    function fractionOfCapOi(IOverlayV1Market market, uint256 oi)
         external
         view
         returns (uint256 fractionOfCapOi_)
     {
-        IOverlayV1Market market = _getMarket(feed);
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         fractionOfCapOi_ = _fractionOfCapOi(market, data, oi);
     }
 
     /// @notice Gets the current funding rate on the Overlay market
-    /// @notice associated with the given feed address
     /// @dev f = 2 * k * ( oiLong - oiShort ) / (oiLong + oiShort)
     /// @dev such that long > short then positive
     /// @return fundingRate_ as the current funding rate
-    function fundingRate(address feed) external view returns (int256 fundingRate_) {
-        IOverlayV1Market market = _getMarket(feed);
+    function fundingRate(IOverlayV1Market market) external view returns (int256 fundingRate_) {
         fundingRate_ = _fundingRate(market);
     }
 
     /// @notice Gets the current level of the circuit breaker for the
-    /// @notice open interest cap on the Overlay market associated with
-    /// @notice the given feed address
+    /// @notice open interest cap on the Overlay market
     /// @dev circuit breaker level is reported as fraction of capOi in FixedPoint
     /// @return circuitBreakerLevel_ as the current circuit breaker level
-    function circuitBreakerLevel(address feed)
+    function circuitBreakerLevel(IOverlayV1Market market)
         external
         view
         returns (uint256 circuitBreakerLevel_)
     {
-        IOverlayV1Market market = _getMarket(feed);
         circuitBreakerLevel_ = _circuitBreakerLevel(market);
     }
 
     /// @notice Gets the current rolling amount minted (+) or burned (-)
-    /// @notice by the Overlay market associated with the given feed address
+    /// @notice by the Overlay market
     /// @dev minted_ > 0 means more OVL has been minted than burned recently
     /// @return minted_ as the current rolling amount minted
-    function minted(address feed) external view returns (int256 minted_) {
-        // cache market
-        IOverlayV1Market market = _getMarket(feed);
-
+    function minted(IOverlayV1Market market) external view returns (int256 minted_) {
         // assemble the rolling amount minted snapshot
         (uint32 timestamp, uint32 window, int192 accumulator) = market.snapshotMinted();
         Roller.Snapshot memory snapshot = Roller.Snapshot({

--- a/contracts/state/OverlayV1OIState.sol
+++ b/contracts/state/OverlayV1OIState.sol
@@ -117,7 +117,11 @@ abstract contract OverlayV1OIState is IOverlayV1OIState, OverlayV1BaseState, Ove
     }
 
     /// @dev circuit breaker level is reported as fraction of capOi in FixedPoint
-    function _circuitBreakerLevel(IOverlayV1Market market) internal view returns (uint256 circuitBreakerLevel_) {
+    function _circuitBreakerLevel(IOverlayV1Market market)
+        internal
+        view
+        returns (uint256 circuitBreakerLevel_)
+    {
         // set cap to ONE as reporting level in terms of % of capOi
         // = market.capNotionalAdjustedForCircuitBreaker(cap) / cap
         circuitBreakerLevel_ = market.capNotionalAdjustedForCircuitBreaker(FixedPoint.ONE);

--- a/contracts/state/OverlayV1PositionState.sol
+++ b/contracts/state/OverlayV1PositionState.sol
@@ -308,117 +308,105 @@ abstract contract OverlayV1PositionState is
         maintenanceMargin_ = q.mulUp(maintenanceMarginFraction);
     }
 
-    /// @notice Gets the position from the Overlay market associated with
-    /// @notice the given feed for the given position owner and position id
+    /// @notice Gets the position from the Overlay market or the given
+    /// @notice position owner and position id
     function position(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (Position.Info memory position_) {
-        IOverlayV1Market market = _getMarket(feed);
         position_ = _getPosition(market, owner, id);
     }
 
     /// @notice Gets the current debt of the position on the Overlay
-    /// @notice market associated with the given feed address for the given
-    /// @notice position owner, id
+    /// @notice market for the given position owner, id
     /// @return debt_ as the current debt taken on by the position
     function debt(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 debt_) {
-        IOverlayV1Market market = _getMarket(feed);
         Position.Info memory position = _getPosition(market, owner, id);
         debt_ = _debt(position);
     }
 
     /// @notice Gets the current cost of the position on the Overlay
-    /// @notice market associated with the given feed address for the given
-    /// @notice position owner, id
+    /// @notice market for the given position owner, id
     /// @return cost_ as the cost to build the position
     function cost(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 cost_) {
-        IOverlayV1Market market = _getMarket(feed);
         Position.Info memory position = _getPosition(market, owner, id);
         cost_ = _cost(position);
     }
 
     /// @notice Gets the current open interest of the position on the Overlay
-    /// @notice market associated with the given feed address for the given
-    /// @notice position owner, id
+    /// @notice market for the given position owner, id
     /// @return oi_ as the current open interest occupied by the position
     function oi(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 oi_) {
-        IOverlayV1Market market = _getMarket(feed);
         Position.Info memory position = _getPosition(market, owner, id);
         oi_ = _oi(market, position);
     }
 
     /// @notice Gets the current collateral backing the position on the
-    /// @notice Overlay market associated with the given feed address
-    /// @notice for the given position owner, id
+    /// @notice Overlay market for the given position owner, id
     /// @dev N(t) = Q * (OI(t) / OI(0)) - D; where Q = notional at build,
     /// @dev OI(t) = current open interest, OI(0) = open interest at build,
     /// @dev D = debt at build
     /// @return collateral_ as the current collateral backing the position
     function collateral(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 collateral_) {
-        IOverlayV1Market market = _getMarket(feed);
         Position.Info memory position = _getPosition(market, owner, id);
         collateral_ = _collateral(market, position);
     }
 
     /// @notice Gets the current value of the position on the Overlay market
-    /// @notice associated with the given feed address for the given
-    /// @notice position owner, id
+    /// @notice for the given position owner, id
     /// @return value_ as the current value of the position
     function value(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 value_) {
-        IOverlayV1Market market = _getMarket(feed);
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         Position.Info memory position = _getPosition(market, owner, id);
         value_ = _value(market, data, position);
     }
 
     /// @notice Gets the current notional of the position on the Overlay market
-    /// @notice associated with the given feed address for the given
-    /// @notice position owner, id (accounts for PnL)
+    /// @notice for the given position owner, id (accounts for PnL)
     /// @return notional_ as the current notional of the position
     function notional(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 notional_) {
-        IOverlayV1Market market = _getMarket(feed);
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         Position.Info memory position = _getPosition(market, owner, id);
         notional_ = _notional(market, data, position);
     }
 
     /// @notice Gets the trading fee charged to unwind the position on the
-    /// @notice Overlay market associated with the given feed address for
-    /// @notice the given position owner, id
+    /// @notice Overlay market for the given position owner, id
     /// @dev tradingFee = notional * tradingFeeRate
     /// @return tradingFee_ as the current trading fee charged
     function tradingFee(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 tradingFee_) {
-        IOverlayV1Market market = _getMarket(feed);
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         Position.Info memory position = _getPosition(market, owner, id);
         uint256 notional = _notional(market, data, position);
@@ -429,46 +417,44 @@ abstract contract OverlayV1PositionState is
     }
 
     /// @notice Gets whether the position is currently liquidatable on the Overlay
-    /// @notice market associated with the given feed address for the given
-    /// @notice position owner, id
+    /// @notice market for the given position owner, id
     /// @return liquidatable_ as whether the position is liquidatable
     function liquidatable(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (bool liquidatable_) {
-        IOverlayV1Market market = _getMarket(feed);
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         Position.Info memory position = _getPosition(market, owner, id);
         liquidatable_ = _liquidatable(market, data, position);
     }
 
     /// @notice Gets the liquidation fee rewarded to the liquidator if
-    /// @notice position currently liquidatable on the Overlay market associated
-    /// @notice with the given feed address for the given position owner, id
+    /// @notice position currently liquidatable on the Overlay market
+    /// @notice for the given position owner, id
     /// @dev liquidationFee_ == 0 if not liquidatable
     /// @return liquidationFee_ as the current liquidation fee reward
     function liquidationFee(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 liquidationFee_) {
-        IOverlayV1Market market = _getMarket(feed);
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         Position.Info memory position = _getPosition(market, owner, id);
         liquidationFee_ = _liquidationFee(market, data, position);
     }
 
     /// @notice Gets the maintenance margin required to keep the position
-    /// @notice open on the Overlay market associated with the given feed
-    /// @notice address for the given position owner, id
+    /// @notice open on the Overlay market for the given position owner, id
     /// @return maintenanceMargin_ as the maintenance margin
     function maintenanceMargin(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 maintenanceMargin_) {
-        IOverlayV1Market market = _getMarket(feed);
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         Position.Info memory position = _getPosition(market, owner, id);
         maintenanceMargin_ = _maintenanceMargin(market, position);
@@ -476,17 +462,16 @@ abstract contract OverlayV1PositionState is
 
     /// @notice Gets the current position remaining margin to eat through
     /// @notice before liquidation occurs on the Overlay market
-    /// @notice associated with the given feed address for the given
-    /// @notice position owner, id
+    /// @notice for the given position owner, id
     /// @dev excess_ > 0: returns excess margin before liquidation
     /// @dev excess_ < 0, returns margin lost due to delayed liquidation
     /// @return excess_ as the current value less maintenance and liq fees
     function marginExcessBeforeLiquidation(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (int256 excess_) {
-        IOverlayV1Market market = _getMarket(feed);
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         Position.Info memory position = _getPosition(market, owner, id);
 
@@ -498,15 +483,14 @@ abstract contract OverlayV1PositionState is
     }
 
     /// @notice Gets the current liquidation price of the position on the
-    /// @notice Overlay market associated with the given feed address
-    /// @notice for the given position owner, id
+    /// @notice Overlay market for the given position owner, id
     /// @return liquidationPrice_ as the current liquidation price
     function liquidationPrice(
-        address feed,
+        IOverlayV1Market market,
         address owner,
         uint256 id
     ) external view returns (uint256 liquidationPrice_) {
-        IOverlayV1Market market = _getMarket(feed);
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         Position.Info memory position = _getPosition(market, owner, id);
 

--- a/contracts/state/OverlayV1PriceState.sol
+++ b/contracts/state/OverlayV1PriceState.sol
@@ -81,72 +81,70 @@ abstract contract OverlayV1PriceState is IOverlayV1PriceState, OverlayV1BaseStat
     }
 
     /// @notice Gets the bid price trader will receive on the Overlay market
-    /// @notice associated with the given feed address given fraction of
-    /// @notice cap on open interest trade represents
+    /// @notice given fraction of cap on open interest trade represents
     /// @dev fractionOfCapOi (i.e. oi / capOi) is FixedPoint
     /// @return bid_ as the received bid price
-    function bid(address feed, uint256 fractionOfCapOi) external view returns (uint256 bid_) {
-        IOverlayV1Market market = _getMarket(feed);
+    function bid(IOverlayV1Market market, uint256 fractionOfCapOi) external view returns (uint256 bid_) {
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         bid_ = _bid(market, data, fractionOfCapOi);
     }
 
     /// @notice Gets the ask price trader will receive on the Overlay market
-    /// @notice associated with the given feed address given fraction of
-    /// @notice cap on open interest trade represents
+    /// @notice given fraction of cap on open interest trade represents
     /// @dev fractionOfCapOi (i.e. oi / capOi) is FixedPoint
     /// @return ask_ as the received ask price
-    function ask(address feed, uint256 fractionOfCapOi) external view returns (uint256 ask_) {
-        IOverlayV1Market market = _getMarket(feed);
+    function ask(IOverlayV1Market market, uint256 fractionOfCapOi) external view returns (uint256 ask_) {
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         ask_ = _ask(market, data, fractionOfCapOi);
     }
 
     /// @notice Gets the mid price from feed used for liquidations
-    /// @notice on the Overlay market associated with the given feed address
+    /// @notice on the Overlay market
     /// @return mid_ as the received mid price
-    function mid(address feed) external view returns (uint256 mid_) {
+    function mid(IOverlayV1Market market) external view returns (uint256 mid_) {
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         mid_ = _mid(data);
     }
 
     /// @notice Gets the rolling volume on the bid after the trader places
-    /// @notice trade on the Overlay market associated with the given feed
-    /// @notice address given fraction of cap on open interest trade represents
+    /// @notice trade on the Overlay market given fraction of cap on
+    /// @notice open interest trade represents
     /// @dev fractionOfCapOi (i.e. oi / capOi) is FixedPoint
     /// @return volumeBid_ as the volume on the bid
-    function volumeBid(address feed, uint256 fractionOfCapOi)
+    function volumeBid(IOverlayV1Market market, uint256 fractionOfCapOi)
         external
         view
         returns (uint256 volumeBid_)
     {
-        IOverlayV1Market market = _getMarket(feed);
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         volumeBid_ = _volumeBid(market, data, fractionOfCapOi);
     }
 
     /// @notice Gets the rolling volume on the ask after the trader places
-    /// @notice trade on the Overlay market associated with the given feed
-    /// @notice address given fraction of cap on open interest trade represents
+    /// @notice trade on the Overlay market given fraction of cap on
+    /// @notice open interest trade represents
     /// @dev fractionOfCapOi (i.e. oi / capOi) is FixedPoint
     /// @return volumeAsk_ as the volume on the ask
-    function volumeAsk(address feed, uint256 fractionOfCapOi)
+    function volumeAsk(IOverlayV1Market market, uint256 fractionOfCapOi)
         external
         view
         returns (uint256 volumeAsk_)
     {
-        IOverlayV1Market market = _getMarket(feed);
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         volumeAsk_ = _volumeAsk(market, data, fractionOfCapOi);
     }
 
     /// @notice Gets the current bid, ask, and mid price values on the
-    /// @notice Overlay market associated with the given feed address
-    /// @notice accounting for recent volume
+    /// @notice Overlay market accounting for recent volume
     /// @return bid_ as the current bid price
     /// @return ask_ as the current ask price
     /// @return mid_ as the current mid price from feed
-    function prices(address feed)
+    function prices(IOverlayV1Market market)
         external
         view
         returns (
@@ -155,8 +153,8 @@ abstract contract OverlayV1PriceState is IOverlayV1PriceState, OverlayV1BaseStat
             uint256 mid_
         )
     {
-        // cache market and feed data
-        IOverlayV1Market market = _getMarket(feed);
+        // cache feed data
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
 
         // use the bid, ask prices assuming zero oi being traded
@@ -169,12 +167,12 @@ abstract contract OverlayV1PriceState is IOverlayV1PriceState, OverlayV1BaseStat
     }
 
     /// @notice Gets the current rolling volume on the bid and ask sides
-    /// @notice of the Overlay market associated with the given feed address
+    /// @notice of the Overlay market
     /// @return volumeBid_ as the current rolling volume on the bid
     /// @return volumeAsk_ as the current rolling volume on the ask
-    function volumes(address feed) external view returns (uint256 volumeBid_, uint256 volumeAsk_) {
-        // cache market and feed data
-        IOverlayV1Market market = _getMarket(feed);
+    function volumes(IOverlayV1Market market) external view returns (uint256 volumeBid_, uint256 volumeAsk_) {
+        // cache feed data
+        address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
 
         // use the bid, ask rolling volumes assuming zero oi being traded

--- a/contracts/state/OverlayV1PriceState.sol
+++ b/contracts/state/OverlayV1PriceState.sol
@@ -84,7 +84,11 @@ abstract contract OverlayV1PriceState is IOverlayV1PriceState, OverlayV1BaseStat
     /// @notice given fraction of cap on open interest trade represents
     /// @dev fractionOfCapOi (i.e. oi / capOi) is FixedPoint
     /// @return bid_ as the received bid price
-    function bid(IOverlayV1Market market, uint256 fractionOfCapOi) external view returns (uint256 bid_) {
+    function bid(IOverlayV1Market market, uint256 fractionOfCapOi)
+        external
+        view
+        returns (uint256 bid_)
+    {
         address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         bid_ = _bid(market, data, fractionOfCapOi);
@@ -94,7 +98,11 @@ abstract contract OverlayV1PriceState is IOverlayV1PriceState, OverlayV1BaseStat
     /// @notice given fraction of cap on open interest trade represents
     /// @dev fractionOfCapOi (i.e. oi / capOi) is FixedPoint
     /// @return ask_ as the received ask price
-    function ask(IOverlayV1Market market, uint256 fractionOfCapOi) external view returns (uint256 ask_) {
+    function ask(IOverlayV1Market market, uint256 fractionOfCapOi)
+        external
+        view
+        returns (uint256 ask_)
+    {
         address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);
         ask_ = _ask(market, data, fractionOfCapOi);
@@ -170,7 +178,11 @@ abstract contract OverlayV1PriceState is IOverlayV1PriceState, OverlayV1BaseStat
     /// @notice of the Overlay market
     /// @return volumeBid_ as the current rolling volume on the bid
     /// @return volumeAsk_ as the current rolling volume on the ask
-    function volumes(IOverlayV1Market market) external view returns (uint256 volumeBid_, uint256 volumeAsk_) {
+    function volumes(IOverlayV1Market market)
+        external
+        view
+        returns (uint256 volumeBid_, uint256 volumeAsk_)
+    {
         // cache feed data
         address feed = market.feed();
         Oracle.Data memory data = _getOracleData(feed);

--- a/tests/state/test_position.py
+++ b/tests/state/test_position.py
@@ -37,7 +37,7 @@ def test_position(state, market, feed, alice, ovl):
 
     # check market position is same as position returned from state
     expect = market.positions(pos_key)
-    actual = state.position(feed, alice.address, pos_id)
+    actual = state.position(market, alice.address, pos_id)
 
     assert expect == actual
 
@@ -63,7 +63,7 @@ def test_debt(state, market, feed, ovl, alice):
 
     # check market position debt same as state queried position debt
     (_, expect_debt, _, _, _, _) = market.positions(pos_key)
-    actual_debt = state.debt(feed, alice.address, pos_id)
+    actual_debt = state.debt(market, alice.address, pos_id)
 
     assert expect_debt == actual_debt
 
@@ -91,7 +91,7 @@ def test_cost(state, market, feed, ovl, alice):
     (expect_notional_initial, expect_debt, _, _,
      _, _) = market.positions(pos_key)
     expect_cost = expect_notional_initial - expect_debt
-    actual_cost = state.cost(feed, alice.address, pos_id)
+    actual_cost = state.cost(market, alice.address, pos_id)
 
     assert expect_cost == actual_cost
 
@@ -120,14 +120,14 @@ def test_oi(state, market, feed, ovl, alice):
     expect_oi_long_shares = market.oiLongShares()
 
     # NOTE: ois() tests in test_oi.py
-    actual_oi_long, _ = state.ois(feed)
+    actual_oi_long, _ = state.ois(market)
 
     # check expect equals actual for position oi
     expect_oi = int(
         Decimal(actual_oi_long) * Decimal(expect_oi_shares)
         / Decimal(expect_oi_long_shares)
     )
-    actual_oi = int(state.oi(feed, alice.address, pos_id))
+    actual_oi = int(state.oi(market, alice.address, pos_id))
     assert expect_oi == approx(actual_oi)
 
     # forward the chain to check oi expectations in line after funding
@@ -135,14 +135,14 @@ def test_oi(state, market, feed, ovl, alice):
 
     # NOTE: ois() tests in test_oi.py
     expect_oi_long_shares = market.oiLongShares()
-    actual_oi_long, _ = state.ois(feed)
+    actual_oi_long, _ = state.ois(market)
 
     # check expect equals actual for position oi
     expect_oi = int(
         Decimal(actual_oi_long) * Decimal(expect_oi_shares)
         / Decimal(expect_oi_long_shares)
     )
-    actual_oi = int(state.oi(feed, alice.address, pos_id))
+    actual_oi = int(state.oi(market, alice.address, pos_id))
     assert expect_oi == approx(actual_oi)
 
 
@@ -171,7 +171,7 @@ def test_collateral(state, market, feed, ovl, alice):
     expect_oi_long_shares = market.oiLongShares()
 
     # NOTE: ois() tests in test_oi.py
-    actual_oi_long, _ = state.ois(feed)
+    actual_oi_long, _ = state.ois(market)
 
     # calculate the expected collateral amount: Q * (OI(t) / OI(0)) - D
     expect_oi = int(
@@ -183,7 +183,7 @@ def test_collateral(state, market, feed, ovl, alice):
                             * (expect_oi / expect_oi_initial) - expect_debt)
 
     # check expect collateral matches actual queried from state
-    actual_collateral = int(state.collateral(feed, alice.address, pos_id))
+    actual_collateral = int(state.collateral(market, alice.address, pos_id))
     assert expect_collateral == approx(actual_collateral)
 
     # forward the chain to check collateral expectations in line after funding
@@ -191,7 +191,7 @@ def test_collateral(state, market, feed, ovl, alice):
 
     # NOTE: ois() tests in test_oi.py
     expect_oi_long_shares = market.oiLongShares()
-    actual_oi_long, _ = state.ois(feed)
+    actual_oi_long, _ = state.ois(market)
 
     # calculate the expected collateral amount: Q * (OI(t) / OI(0)) - D
     expect_oi = int(
@@ -203,7 +203,7 @@ def test_collateral(state, market, feed, ovl, alice):
                             * (expect_oi / expect_oi_initial) - expect_debt)
 
     # check expect collateral matches actual queried from state
-    actual_collateral = int(state.collateral(feed, alice.address, pos_id))
+    actual_collateral = int(state.collateral(market, alice.address, pos_id))
     assert expect_collateral == approx(actual_collateral)
 
 
@@ -235,7 +235,7 @@ def test_value(state, market, feed, ovl, alice, is_long):
         else market.oiShortShares()
 
     # NOTE: ois() tests in test_oi.py
-    actual_oi_long, actual_oi_short = state.ois(feed)
+    actual_oi_long, actual_oi_short = state.ois(market)
     actual_oi_tot_on_side = actual_oi_long if is_long else actual_oi_short
 
     # calculate the expected value of position
@@ -251,11 +251,11 @@ def test_value(state, market, feed, ovl, alice, is_long):
     expect_entry_price = int(expect_entry_price)
 
     # NOTE: fractionOfCapOi tests in test_oi.py
-    frac_cap_oi = state.fractionOfCapOi(feed, expect_oi)
+    frac_cap_oi = state.fractionOfCapOi(market, expect_oi)
 
     # NOTE: bid, ask tests in test_price.py
     expect_exit_price = state.bid(
-        feed, frac_cap_oi) if is_long else state.ask(feed, frac_cap_oi)
+        market, frac_cap_oi) if is_long else state.ask(market, frac_cap_oi)
     expect_exit_price = int(expect_exit_price)
 
     # calculate value with collateral + PnL from price deltas
@@ -268,7 +268,7 @@ def test_value(state, market, feed, ovl, alice, is_long):
     expect_value = int(expect_collateral + expect_pnl)
 
     # check expect value in line with actual from state
-    actual_value = int(state.value(feed, alice.address, pos_id))
+    actual_value = int(state.value(market, alice.address, pos_id))
     assert expect_value == approx(actual_value)
 
 
@@ -300,7 +300,7 @@ def test_notional(state, market, feed, ovl, alice, is_long):
         else market.oiShortShares()
 
     # NOTE: ois() tests in test_oi.py
-    actual_oi_long, actual_oi_short = state.ois(feed)
+    actual_oi_long, actual_oi_short = state.ois(market)
     actual_oi_tot_on_side = actual_oi_long if is_long else actual_oi_short
 
     # calculate the expected value of position
@@ -316,11 +316,11 @@ def test_notional(state, market, feed, ovl, alice, is_long):
     expect_entry_price = int(expect_entry_price)
 
     # NOTE: fractionOfCapOi tests in test_oi.py
-    frac_cap_oi = state.fractionOfCapOi(feed, expect_oi)
+    frac_cap_oi = state.fractionOfCapOi(market, expect_oi)
 
     # NOTE: bid, ask tests in test_price.py
     expect_exit_price = state.bid(
-        feed, frac_cap_oi) if is_long else state.ask(feed, frac_cap_oi)
+        market, frac_cap_oi) if is_long else state.ask(market, frac_cap_oi)
     expect_exit_price = int(expect_exit_price)
 
     # calculate value with collateral + PnL + debt from price deltas
@@ -334,7 +334,7 @@ def test_notional(state, market, feed, ovl, alice, is_long):
     expect_notional = int(expect_collateral + expect_pnl + expect_debt)
 
     # check expect notional in line with actual from state
-    actual_notional = int(state.notional(feed, alice.address, pos_id))
+    actual_notional = int(state.notional(market, alice.address, pos_id))
     assert expect_notional == approx(actual_notional)
 
 
@@ -366,7 +366,7 @@ def test_trading_fee(state, market, feed, ovl, alice, is_long):
         else market.oiShortShares()
 
     # NOTE: ois() tests in test_oi.py
-    actual_oi_long, actual_oi_short = state.ois(feed)
+    actual_oi_long, actual_oi_short = state.ois(market)
     actual_oi_tot_on_side = actual_oi_long if is_long else actual_oi_short
 
     # calculate the expected value of position
@@ -382,11 +382,11 @@ def test_trading_fee(state, market, feed, ovl, alice, is_long):
     expect_entry_price = int(expect_entry_price)
 
     # NOTE: fractionOfCapOi tests in test_oi.py
-    frac_cap_oi = state.fractionOfCapOi(feed, expect_oi)
+    frac_cap_oi = state.fractionOfCapOi(market, expect_oi)
 
     # NOTE: bid, ask tests in test_price.py
     expect_exit_price = state.bid(
-        feed, frac_cap_oi) if is_long else state.ask(feed, frac_cap_oi)
+        market, frac_cap_oi) if is_long else state.ask(market, frac_cap_oi)
     expect_exit_price = int(expect_exit_price)
 
     # calculate value with collateral + PnL + debt from price deltas
@@ -407,7 +407,7 @@ def test_trading_fee(state, market, feed, ovl, alice, is_long):
         expect_trading_fee_rate) * expect_notional / Decimal(1e18)
 
     # check expect trade fee in line with actual from state
-    actual_trading_fee = int(state.tradingFee(feed, alice.address, pos_id))
+    actual_trading_fee = int(state.tradingFee(market, alice.address, pos_id))
     assert expect_trading_fee == approx(actual_trading_fee)
 
 
@@ -440,20 +440,22 @@ def test_liquidatable(state, mock_market, mock_feed, ovl, alice, is_long):
 
     # check not liquidatable
     expect_liquidatable = False
-    actual_liquidatable = state.liquidatable(mock_feed, alice.address, pos_id)
+    actual_liquidatable = state.liquidatable(
+        mock_market, alice.address, pos_id)
     assert expect_liquidatable == actual_liquidatable
 
     # set price to just beyond liquidation price and make sure liquidatable
     # NOTE: liquidationPrice() tests below in test_liquidation_price
     expect_liquidation_price = state.liquidationPrice(
-        mock_feed, alice.address, pos_id)
+        mock_market, alice.address, pos_id)
     mock_feed_price = expect_liquidation_price * \
         (1 - tol) if is_long else expect_liquidation_price * (1 + tol)
     mock_feed.setPrice(mock_feed_price, {"from": alice})
 
     # check liquidatable
     expect_liquidatable = True
-    actual_liquidatable = state.liquidatable(mock_feed, alice.address, pos_id)
+    actual_liquidatable = state.liquidatable(
+        mock_market, alice.address, pos_id)
     assert expect_liquidatable == actual_liquidatable
 
     # set price to just before liquidation price and make sure not liquidatable
@@ -463,7 +465,8 @@ def test_liquidatable(state, mock_market, mock_feed, ovl, alice, is_long):
 
     # check no longer liquidatable
     expect_liquidatable = False
-    actual_liquidatable = state.liquidatable(mock_feed, alice.address, pos_id)
+    actual_liquidatable = state.liquidatable(
+        mock_market, alice.address, pos_id)
     assert expect_liquidatable == actual_liquidatable
 
 
@@ -489,7 +492,7 @@ def test_liquidation_fee(state, mock_market, mock_feed, ovl, alice, is_long):
     # set price to just beyond liquidation price
     # NOTE: liquidationPrice() tests below in test_liquidation_price
     expect_liquidation_price = state.liquidationPrice(
-        mock_feed, alice.address, pos_id)
+        mock_market, alice.address, pos_id)
     mock_feed_price = expect_liquidation_price * \
         (1 - tol) if is_long else expect_liquidation_price * (1 + tol)
     mock_feed.setPrice(mock_feed_price, {"from": alice})
@@ -505,7 +508,7 @@ def test_liquidation_fee(state, mock_market, mock_feed, ovl, alice, is_long):
         else mock_market.oiShortShares()
 
     # NOTE: ois() tests in test_oi.py
-    actual_oi_long, actual_oi_short = state.ois(mock_feed)
+    actual_oi_long, actual_oi_short = state.ois(mock_market)
     actual_oi_tot_on_side = actual_oi_long if is_long else actual_oi_short
 
     # calculate the expected value of position
@@ -522,7 +525,7 @@ def test_liquidation_fee(state, mock_market, mock_feed, ovl, alice, is_long):
 
     # mid used for liquidation exit (manipulation resistant)
     # NOTE: mid tests in test_price.py
-    expect_exit_price = state.mid(mock_feed)
+    expect_exit_price = state.mid(mock_market)
     expect_exit_price = int(expect_exit_price)
 
     # calculate value with collateral + PnL from price deltas
@@ -542,7 +545,7 @@ def test_liquidation_fee(state, mock_market, mock_feed, ovl, alice, is_long):
 
     # check expect liq fee reward in line with actual
     actual_liq_fee = int(state.liquidationFee(
-        mock_feed, alice.address, pos_id))
+        mock_market, alice.address, pos_id))
     assert expect_liq_fee == approx(actual_liq_fee)
 
 
@@ -579,7 +582,7 @@ def test_maintenance_margin(state, market, feed, ovl, alice):
 
     # check expect maintenance in line with actual from state
     actual_maintenance_margin = int(
-        state.maintenanceMargin(feed, alice.address, pos_id))
+        state.maintenanceMargin(market, alice.address, pos_id))
     assert expect_maintenance_margin == approx(actual_maintenance_margin)
 
 
@@ -607,7 +610,7 @@ def test_margin_excess_before_liquidation(state, mock_market, mock_feed,
     # set price to just before liquidation price
     # NOTE: liquidationPrice() tests below in test_liquidation_price
     expect_liquidation_price = state.liquidationPrice(
-        mock_feed, alice.address, pos_id)
+        mock_market, alice.address, pos_id)
     mock_feed_price = expect_liquidation_price * \
         (1 + tol) if is_long else expect_liquidation_price * (1 - tol)
     mock_feed.setPrice(mock_feed_price, {"from": alice})
@@ -623,7 +626,7 @@ def test_margin_excess_before_liquidation(state, mock_market, mock_feed,
         else mock_market.oiShortShares()
 
     # NOTE: ois() tests in test_oi.py
-    actual_oi_long, actual_oi_short = state.ois(mock_feed)
+    actual_oi_long, actual_oi_short = state.ois(mock_market)
     actual_oi_tot_on_side = actual_oi_long if is_long else actual_oi_short
 
     # calculate the expected value of position
@@ -640,7 +643,7 @@ def test_margin_excess_before_liquidation(state, mock_market, mock_feed,
 
     # mid used for liquidation exit (manipulation resistant)
     # NOTE: mid tests in test_price.py
-    expect_exit_price = state.mid(mock_feed)
+    expect_exit_price = state.mid(mock_market)
     expect_exit_price = int(expect_exit_price)
 
     # calculate value with collateral + PnL from price deltas
@@ -658,17 +661,17 @@ def test_margin_excess_before_liquidation(state, mock_market, mock_feed,
     # calculate expect liquidation fee as percentage on expected value left
     # NOTE: liquidationFee tests above
     expect_liq_fee = int(state.liquidationFee(
-        mock_feed, alice.address, pos_id))
+        mock_market, alice.address, pos_id))
 
     # calculate the expect maintenance margin
     # NOTE: maintenanceMargin tests above
     expect_maintenance_margin = int(
-        state.maintenanceMargin(mock_feed, alice.address, pos_id))
+        state.maintenanceMargin(mock_market, alice.address, pos_id))
 
     # calculate expected excess
     expect_excess = expect_value - expect_maintenance_margin - expect_liq_fee
     actual_excess = int(state.marginExcessBeforeLiquidation(
-        mock_feed, alice.address, pos_id))
+        mock_market, alice.address, pos_id))
 
     # TODO: why rel tol needed here?
     assert expect_excess == approx(actual_excess, rel=1e-3)
@@ -676,14 +679,14 @@ def test_margin_excess_before_liquidation(state, mock_market, mock_feed,
     # repeat the same when excess < 0
     # set price to just beyond liquidation price
     expect_liquidation_price = state.liquidationPrice(
-        mock_feed, alice.address, pos_id)
+        mock_market, alice.address, pos_id)
     mock_feed_price = expect_liquidation_price * \
         (1 - tol) if is_long else expect_liquidation_price * (1 + tol)
     mock_feed.setPrice(mock_feed_price, {"from": alice})
 
     # mid used for liquidation exit (manipulation resistant)
     # NOTE: mid tests in test_price.py
-    expect_exit_price = state.mid(mock_feed)
+    expect_exit_price = state.mid(mock_market)
     expect_exit_price = int(expect_exit_price)
 
     # calculate value with collateral + PnL from price deltas
@@ -701,17 +704,17 @@ def test_margin_excess_before_liquidation(state, mock_market, mock_feed,
     # calculate expect liquidation fee as percentage on expected value left
     # NOTE: liquidationFee tests above
     expect_liq_fee = int(state.liquidationFee(
-        mock_feed, alice.address, pos_id))
+        mock_market, alice.address, pos_id))
 
     # calculate the expect maintenance margin
     # NOTE: maintenanceMargin tests above
     expect_maintenance_margin = int(
-        state.maintenanceMargin(mock_feed, alice.address, pos_id))
+        state.maintenanceMargin(mock_market, alice.address, pos_id))
 
     # calculate expected excess
     expect_excess = expect_value - expect_maintenance_margin - expect_liq_fee
     actual_excess = int(state.marginExcessBeforeLiquidation(
-        mock_feed, alice.address, pos_id))
+        mock_market, alice.address, pos_id))
 
     # TODO: why rel tol needed here?
     assert expect_excess == approx(actual_excess, rel=1e-3)
@@ -745,7 +748,7 @@ def test_liquidation_price(state, market, feed, ovl, alice, is_long):
         else market.oiShortShares()
 
     # NOTE: ois() tests in test_oi.py
-    actual_oi_long, actual_oi_short = state.ois(feed)
+    actual_oi_long, actual_oi_short = state.ois(market)
     actual_oi_tot_on_side = actual_oi_long if is_long else actual_oi_short
 
     # calculate the expected value of position
@@ -787,7 +790,7 @@ def test_liquidation_price(state, market, feed, ovl, alice, is_long):
 
     # check expect liq price in line with actual from state
     actual_liquidation_price = int(
-        state.liquidationPrice(feed, alice.address, pos_id))
+        state.liquidationPrice(market, alice.address, pos_id))
     assert expect_liquidation_price == approx(actual_liquidation_price)
 
 
@@ -795,4 +798,4 @@ def test_liquidation_price_reverts_when_oi_is_zero(state, market, feed,
                                                    ovl, alice):
     # try for a position that doesn't exist
     with reverts("OVLV1: oi == 0"):
-        _ = state.liquidationPrice(feed, alice.address, 0)
+        _ = state.liquidationPrice(market, alice.address, 0)

--- a/tests/state/test_price.py
+++ b/tests/state/test_price.py
@@ -16,7 +16,7 @@ def test_mid(state, market, feed):
     data = feed.latest()
 
     expect = int(mid_from_feed(data))
-    actual = state.mid(feed)
+    actual = state.mid(market)
 
     assert expect == approx(actual)
 
@@ -38,7 +38,7 @@ def test_bid(state, market, feed, fraction):
     (_, _, accumulator) = snap
 
     expect = market.bid(data, accumulator)
-    actual = state.bid(feed, fraction)
+    actual = state.bid(market, fraction)
     assert expect == actual
 
 
@@ -80,7 +80,7 @@ def test_bid_when_oi_on_market(state, market, feed, initial_fraction,
     (_, _, accumulator) = snap
 
     expect = int(market.bid(data, accumulator))
-    actual = int(state.bid(feed, fraction))
+    actual = int(state.bid(market, fraction))
     assert expect == approx(actual)
 
 
@@ -101,7 +101,7 @@ def test_ask(state, market, feed, fraction):
     (_, _, accumulator) = snap
 
     expect = market.ask(data, accumulator)
-    actual = state.ask(feed, fraction)
+    actual = state.ask(market, fraction)
     assert expect == actual
 
 
@@ -143,7 +143,7 @@ def test_ask_when_oi_on_market(state, market, feed, initial_fraction,
     (_, _, accumulator) = snap
 
     expect = int(market.ask(data, accumulator))
-    actual = int(state.ask(feed, fraction))
+    actual = int(state.ask(market, fraction))
     assert expect == approx(actual)
 
 
@@ -169,7 +169,7 @@ def test_prices(state, market, feed):
     expect_ask = int(market.ask(data, accumulator_ask))
     expect_mid = int(mid_from_feed(data))
 
-    (actual_bid, actual_ask, actual_mid) = state.prices(feed)
+    (actual_bid, actual_ask, actual_mid) = state.prices(market)
 
     assert expect_bid == approx(int(actual_bid))
     assert expect_ask == approx(int(actual_ask))
@@ -231,7 +231,7 @@ def test_prices_when_oi_on_market(state, market, feed, ovl, alice, bob,
     expect_ask = int(market.ask(data, accumulator_ask))
     expect_mid = int(mid_from_feed(data))
 
-    (actual_bid, actual_ask, actual_mid) = state.prices(feed)
+    (actual_bid, actual_ask, actual_mid) = state.prices(market)
 
     assert expect_bid == approx(int(actual_bid))
     assert expect_ask == approx(int(actual_ask))

--- a/tests/state/test_state.py
+++ b/tests/state/test_state.py
@@ -1,4 +1,4 @@
-def test_state(state, market, feed, ovl, alice, bob):
+def test_market_state(state, market, feed, ovl, alice, bob):
     # alice build params
     input_collateral_alice = 20000000000000000000  # 20
     input_leverage_alice = 1000000000000000000  # 1
@@ -37,5 +37,5 @@ def test_state(state, market, feed, ovl, alice, bob):
 
     expect = (bid, ask, mid, volume_bid, volume_ask, oi_long, oi_short,
               cap_oi, circuit_level, funding_rate)
-    actual = state.state(feed)
+    actual = state.marketState(feed)
     assert expect == actual

--- a/tests/state/test_state.py
+++ b/tests/state/test_state.py
@@ -25,17 +25,17 @@ def test_market_state(state, market, feed, ovl, alice, bob):
 
     # query all the views from OverlayV1PriceState, OverlayV1OIState
     # NOTE: tests in test_price.py, test_volume.py and test_oi.py
-    bid = state.bid(feed, 0)
-    ask = state.ask(feed, 0)
-    mid = state.mid(feed)
-    volume_bid = state.volumeBid(feed, 0)
-    volume_ask = state.volumeAsk(feed, 0)
-    oi_long, oi_short = state.ois(feed)
-    cap_oi = state.capOi(feed)
-    circuit_level = state.circuitBreakerLevel(feed)
-    funding_rate = state.fundingRate(feed)
+    bid = state.bid(market, 0)
+    ask = state.ask(market, 0)
+    mid = state.mid(market)
+    volume_bid = state.volumeBid(market, 0)
+    volume_ask = state.volumeAsk(market, 0)
+    oi_long, oi_short = state.ois(market)
+    cap_oi = state.capOi(market)
+    circuit_level = state.circuitBreakerLevel(market)
+    funding_rate = state.fundingRate(market)
 
     expect = (bid, ask, mid, volume_bid, volume_ask, oi_long, oi_short,
               cap_oi, circuit_level, funding_rate)
-    actual = state.marketState(feed)
+    actual = state.marketState(market)
     assert expect == actual

--- a/tests/state/test_state.py
+++ b/tests/state/test_state.py
@@ -1,0 +1,41 @@
+def test_state(state, market, feed, ovl, alice, bob):
+    # alice build params
+    input_collateral_alice = 20000000000000000000  # 20
+    input_leverage_alice = 1000000000000000000  # 1
+    input_is_long_alice = True
+    input_price_limit_alice = 2**256-1
+
+    # bob build params
+    input_collateral_bob = 10000000000000000000  # 10
+    input_leverage_bob = 1000000000000000000  # 1
+    input_is_long_bob = False
+    input_price_limit_bob = 0
+
+    # approve max for both
+    ovl.approve(market, 2**256-1, {"from": alice})
+    ovl.approve(market, 2**256-1, {"from": bob})
+
+    # build position for alice
+    market.build(input_collateral_alice, input_leverage_alice,
+                 input_is_long_alice, input_price_limit_alice, {"from": alice})
+
+    # build position for bob
+    market.build(input_collateral_bob, input_leverage_bob,
+                 input_is_long_bob, input_price_limit_bob, {"from": bob})
+
+    # query all the views from OverlayV1PriceState, OverlayV1OIState
+    # NOTE: tests in test_price.py, test_volume.py and test_oi.py
+    bid = state.bid(feed, 0)
+    ask = state.ask(feed, 0)
+    mid = state.mid(feed)
+    volume_bid = state.volumeBid(feed, 0)
+    volume_ask = state.volumeAsk(feed, 0)
+    oi_long, oi_short = state.ois(feed)
+    cap_oi = state.capOi(feed)
+    circuit_level = state.circuitBreakerLevel(feed)
+    funding_rate = state.fundingRate(feed)
+
+    expect = (bid, ask, mid, volume_bid, volume_ask, oi_long, oi_short,
+              cap_oi, circuit_level, funding_rate)
+    actual = state.state(feed)
+    assert expect == actual

--- a/tests/state/test_volume.py
+++ b/tests/state/test_volume.py
@@ -50,7 +50,7 @@ def test_volume_bid(state, market, feed, initial_fraction,
     (_, _, accumulator) = snap
 
     expect = int(accumulator)
-    actual = int(state.volumeBid(feed, fraction))
+    actual = int(state.volumeBid(market, fraction))
 
     assert expect == approx(actual)
 
@@ -93,7 +93,7 @@ def test_volume_ask(state, market, feed, initial_fraction,
     (_, _, accumulator) = snap
 
     expect = int(accumulator)
-    actual = int(state.volumeAsk(feed, fraction))
+    actual = int(state.volumeAsk(market, fraction))
 
     assert expect == approx(actual)
 
@@ -152,7 +152,7 @@ def test_volumes(state, market, feed, ovl, alice, bob,
     expect_volume_bid = int(accumulator_bid)
     expect_volume_ask = int(accumulator_ask)
 
-    (actual_volume_bid, actual_volume_ask) = state.volumes(feed)
+    (actual_volume_bid, actual_volume_ask) = state.volumes(market)
 
     assert expect_volume_bid == approx(int(actual_volume_bid))
     assert expect_volume_ask == approx(int(actual_volume_ask))


### PR DESCRIPTION
Modifies state view input param to give an `IOverlayV1Market market` instead of `address feed`.